### PR TITLE
Fix Typo in Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ service.
 
    ```bash
    # After you have uncommented the two reviews deployments
-   kubctl apply -f bookinfo.yml
+   kubectl apply -f bookinfo.yml
    ```
 
 2. Refresh Productpage in your web browser. You will see that each time you


### PR DESCRIPTION
The spelling of `kubectl` is incorrect in the example under section *2.6*